### PR TITLE
Support universal MacOS builds

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,6 +1,6 @@
 name: Build CI
 
-on: [push, pull_request]
+on: [push, pull_request, workflow_dispatch]
 
 jobs:
   linux-debug:

--- a/SConstruct
+++ b/SConstruct
@@ -51,7 +51,7 @@ if platform == "osx":
         flags.extend(["-arch", env["macos_arch"]])
     
     env.Append(LINKFLAGS=flags)
-    env.Append(CCFLAGS=flags)
+    env.Append(CCFLAGS=flags + ["-std=c++14"])
     
 elif platform == "linux":
     if target in ("debug", "d"):

--- a/SConstruct
+++ b/SConstruct
@@ -1,96 +1,95 @@
 #!python
-import os, subprocess
+import os
 
 opts = Variables([], ARGUMENTS)
+
+# Define the relative path to the Godot headers.
+godot_headers_path = "godot-cpp/godot-headers"
+godot_bindings_path = "godot-cpp"
 
 # Gets the standard flags CC, CCX, etc.
 env = DefaultEnvironment()
 
-# Define our options
-opts.Add(EnumVariable('target', "Compilation target", 'debug', ['d', 'debug', 'r', 'release']))
-opts.Add(EnumVariable('platform', "Compilation platform", '', ['', 'x11', 'linux', 'osx']))
-opts.Add(EnumVariable('p', "Compilation target, alias for 'platform'", '', ['', 'x11', 'linux', 'osx']))
-opts.Add(BoolVariable('use_llvm', "Use the LLVM / Clang compiler", 'no'))
-opts.Add(PathVariable('target_path', 'The path where the lib is installed.', 'bin/'))
-opts.Add(PathVariable('target_name', 'The library name.', 'unixsocket', PathVariable.PathAccept))
-
-# Local dependency paths, adapt them to your setup
-godot_headers_path = "godot-cpp/godot-headers/"
-cpp_bindings_path = "godot-cpp/"
-cpp_library = "libgodot-cpp"
-
-# only support 64 at this time..
-bits = 64
+# Define our options. Use future-proofed names for platforms.
+platform_array = ["", "linuxbsd", "macos", "x11", "linux", "osx"]
+opts.Add(EnumVariable("target", "Compilation target", "debug", ["d", "debug", "r", "release"]))
+opts.Add(EnumVariable("platform", "Compilation platform", "", platform_array))
+opts.Add(EnumVariable("p", "Alias for 'platform'", "", platform_array))
+opts.Add(BoolVariable("use_llvm", "Use the LLVM / Clang compiler", "no"))
+opts.Add(PathVariable("target_path", "The path where the lib is installed.", "bin/"))
+opts.Add(PathVariable("target_name", "The library name.", "unixsocket", PathVariable.PathAccept))
 
 # Updates the environment with the option variables.
 opts.Update(env)
 
-# Process some arguments
-if env['use_llvm']:
-    env['CC'] = 'clang'
-    env['CXX'] = 'clang++'
+# Process platform arguments. Here we use the same names as GDNative.
+if env["p"] != "":
+    env["platform"] = env["p"]
 
-if env['p'] != '':
-    env['platform'] = env['p']
+if env["platform"] == "macos":
+    env["platform"] = "osx"
+elif env["platform"] in ("x11", "linuxbsd"):
+    env["platform"] = "linux"
 
-if env['platform'] == '':
+if env["platform"] == "":
     print("No valid target platform selected.")
-    quit();
+    quit()
 
-# Check our platform specifics
-if env['platform'] == "osx":
-    env['target_path'] += 'osx/'
-    cpp_library += '.osx'
-    if env['target'] in ('debug', 'd'):
-        env.Append(CCFLAGS = ['-g','-O2', '-arch', 'x86_64', '-std=c++17'])
-        env.Append(LINKFLAGS = ['-arch', 'x86_64'])
+platform = env["platform"]
+target = env["target"]
+
+# Check our platform specifics.
+if platform == "osx":
+    if not env["use_llvm"]:
+        env["use_llvm"] = "yes"
+
+    flags = list(("-g", "-O2") if target in ("debug", "d") else ("-g", "-O3"))
+    if env["macos_arch"] == "universal":
+        flags.extend(["-arch", "x86_64", "-arch", "arm64"])
     else:
-        env.Append(CCFLAGS = ['-g','-O3', '-arch', 'x86_64', '-std=c++17'])
-        env.Append(LINKFLAGS = ['-arch', 'x86_64'])
-
-elif env['platform'] in ('x11', 'linux'):
-    env['target_path'] += 'x11/'
-    cpp_library += '.linux'
-    if env['target'] in ('debug', 'd'):
-        env.Append(CCFLAGS = ['-fPIC', '-g3','-Og', '-std=c++17'])
+        flags.extend(["-arch", env["macos_arch"]])
+    
+    env.Append(LINKFLAGS=flags)
+    env.Append(CCFLAGS=flags)
+    
+elif platform == "linux":
+    if target in ("debug", "d"):
+        env.Append(CCFLAGS=["-fPIC", "-g3", "-Og"])
     else:
-        env.Append(CCFLAGS = ['-fPIC', '-g','-O3', '-std=c++17'])
+        env.Append(CCFLAGS=["-fPIC", "-g", "-O3"])
 
-elif env['platform'] == "windows":
-    env['target_path'] += 'win64/'
-    cpp_library += '.windows'
-    # This makes sure to keep the session environment variables on windows,
-    # that way you can run scons in a vs 2017 prompt and it will find all the required tools
-    env.Append(ENV = os.environ)
+if env["use_llvm"] == "yes":
+    env["CC"] = "clang"
+    env["CXX"] = "clang++"
 
-    env.Append(CCFLAGS = ['-DWIN32', '-D_WIN32', '-D_WINDOWS', '-W3', '-GR', '-D_CRT_SECURE_NO_WARNINGS'])
-    if env['target'] in ('debug', 'd'):
-        env.Append(CCFLAGS = ['-EHsc', '-D_DEBUG', '-MDd'])
-    else:
-        env.Append(CCFLAGS = ['-O2', '-EHsc', '-DNDEBUG', '-MD'])
+SConscript("godot-cpp/SConstruct")
 
-if env['target'] in ('debug', 'd'):
-    cpp_library += '.debug'
-else:
-    cpp_library += '.release'
 
-if env['platform'] == 'osx':
-    cpp_library += '.universal'
-else:
-    cpp_library += '.' + str(bits)
+def add_sources(sources, dir):
+    for f in os.listdir(dir):
+        if f.endswith(".cpp"):
+            sources.append(dir + "/" + f)
 
-# make sure our binding library is properly includes
-env.Append(CPPPATH=['.', godot_headers_path, cpp_bindings_path + 'include/', cpp_bindings_path + 'include/core/', cpp_bindings_path + 'include/gen/'])
-env.Append(LIBPATH=[cpp_bindings_path + 'bin/'])
-env.Append(LIBS=[cpp_library])
 
-# tweak this if you want to use different folders, or more folders, to store your source code in.
-env.Append(CPPPATH=['src/'])
-sources = Glob('src/*.cpp')
+env.Append(
+    CPPPATH=[
+        godot_headers_path,
+        godot_bindings_path + "/include",
+        godot_bindings_path + "/include/gen/",
+        godot_bindings_path + "/include/core/",
+    ]
+)
 
-library = env.SharedLibrary(target=env['target_path'] + env['target_name'] , source=sources)
-print(env['target_path'] + env['target_name'])
+env.Append(
+    LIBS=[
+        env.File(os.path.join("godot-cpp/bin", "libgodot-cpp.%s.%s.64%s" % (platform, env["target"], env["LIBSUFFIX"])))
+    ]
+)
+
+env.Append(LIBPATH=[godot_bindings_path + "/bin/"])
+
+sources = []
+add_sources(sources, "src")
+
+library = env.SharedLibrary(target=env["target_path"] + "/" + platform + "/" + env["target_name"], source=sources)
 Default(library)
-
-# Generates help for the -h scons option.
-Help(opts.GenerateHelpText(env))

--- a/SConstruct
+++ b/SConstruct
@@ -13,6 +13,7 @@ env = DefaultEnvironment()
 # Define our options. Use future-proofed names for platforms.
 platform_array = ["", "linuxbsd", "macos", "x11", "linux", "osx"]
 opts.Add(EnumVariable("target", "Compilation target", "debug", ["d", "debug", "r", "release"]))
+opts.Add(EnumVariable("macos_arch", "Target macOS architecture", "universal", ["universal", "x86_64", "arm64"]))
 opts.Add(EnumVariable("platform", "Compilation platform", "", platform_array))
 opts.Add(EnumVariable("p", "Alias for 'platform'", "", platform_array))
 opts.Add(BoolVariable("use_llvm", "Use the LLVM / Clang compiler", "no"))

--- a/build_linux.sh
+++ b/build_linux.sh
@@ -1,12 +1,8 @@
 #!/bin/sh
-	
-cd godot-cpp/
-CORES=$(grep -c \^processor /proc/cpuinfo 2>/dev/null || sysctl -n hw.ncpu)
-scons platform=linux target=$1 generate_bindings=yes bits=64 -j$CORES
-cd ..
+target=$1
 
 if [ ! -d bin ]; then
     mkdir bin
 fi
 
-scons platform=x11 target=$1
+scons platform=linux target=$target generate_bindings=yes bits=64 -j$(nproc)

--- a/build_mac.sh
+++ b/build_mac.sh
@@ -1,18 +1,8 @@
 #!/bin/sh
-
 target=$1
-
-cd godot-cpp/
-CORES=$(grep -c ^processor /proc/cpuinfo 2>/dev/null || sysctl -n hw.ncpu)
-scons platform=osx target=$target generate_bindings=yes macos_arch=x86_64 -j$CORES
-scons platform=osx target=$target generate_bindings=yes macos_arch=arm64 -j$CORES
-
-lipo -create ./bin/libgodot-cpp.osx.${target}.x86_64.a ./bin/libgodot-cpp.osx.${target}.arm64.a -output ./bin/libgodot-cpp.osx.${target}.universal.a
-cd ..
-
 
 if [ ! -d bin ]; then
     mkdir bin
 fi
 
-scons platform=osx target=$target
+scons platform=osx macos_arch=universal target=$target generate_bindings=yes bits=64 -j$(sysctl -n hw.logicalcpu)


### PR DESCRIPTION
MacOS builds are now compiled to target `x86_64` and `arm64` architectures which should solve reported issues on dependent projects:
- 3ddelano/godot-editor-discord-presence/issues/4
- ninstar/Rich-Presence-U#16